### PR TITLE
[gh_worklow] Build and push snap on release

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -3,10 +3,13 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - published
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     concurrency:
       group: snap-build
       cancel-in-progress: true
@@ -25,8 +28,16 @@ jobs:
     - run: |
         sudo sos help
     - uses: snapcore/action-publish@v1
+      if: ${{ github.event_name == 'push' }}
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
         snap: ${{ steps.build-snap.outputs.snap }}
         release: "latest/edge"
+    - uses: snapcore/action-publish@v1
+      if: ${{ github.event_name == 'release' }}
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build-snap.outputs.snap }}
+        release: "latest/candidate"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,7 @@ parts:
       - python3
       - snapcraft
       - gettext
+      - python3-venv
     stage-packages:
       - python3.10-minimal
       - libpython3.10-minimal


### PR DESCRIPTION
Adding workdlow to publish the released sos to the latest/candidate channel when the a new release is created via the tag. This ensures less mannual intervention for future releases.

Update the snap creation for anyone building manually, and need python3-venv as a build dependancy.

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?